### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -15,10 +15,10 @@ jobs:
         docker-stage: [builder, development, production]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -57,13 +57,13 @@ jobs:
         fi
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # v5.3.1
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
       with:
         name: test-results-py${{ matrix.python-version }}-${{ matrix.docker-stage }}
         path: |
@@ -83,6 +83,6 @@ jobs:
     steps:
       - uses: actions/checkout@main
       - name: Run Safety CLI to check for vulnerabilities
-        uses: pyupio/safety-action@v1
+        uses: pyupio/safety-action@2591cf2f3e67ba68b923f4c92f0d36e281c65023  # v1.0.1
         with:
           api-key: ${{ secrets.SAFETY_API_KEY }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,12 +16,12 @@ jobs:
       packages: write
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: '3.13'
         cache: 'pip'
@@ -76,7 +76,7 @@ jobs:
         echo "- \`threatflux/batch-api:${{ steps.get_version.outputs.version }}-builder\` (builder)" >> RELEASE_NOTES.md
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
       with:
         tag_name: v${{ steps.get_version.outputs.version }}
         name: Release v${{ steps.get_version.outputs.version }}
@@ -91,7 +91,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
       with:
         name: release-artifacts-v${{ steps.get_version.outputs.version }}
         path: |
@@ -103,7 +103,7 @@ jobs:
         compression-level: 9
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -129,7 +129,7 @@ jobs:
 
     - name: Notify on failure
       if: failure()
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           github.rest.issues.create({

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -13,10 +13,10 @@ jobs:
       pull-requests: write # Needed for creating PRs
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@20250223.1.17
+        uses: ThreatFlux/githubWorkFlowChecker@fda84ac30f6fdf8548b96f9e1ece3e47e02c463e  # 20250223.1.17
         with:
           token: ${{ secrets.GIT_TOKEN }}
           owner: ThreatFlux

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -16,13 +16,13 @@ jobs:
       contents: write
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38  # v5.4.0
       with:
         python-version: '3.13'
 


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/setup-python`
  * From: v5 ()
  * To: v5.4.0 (42375524e23c412d93fb67b49958b491fce71c38)

* `codecov/codecov-action`
  * From: v4 ()
  * To: v5.3.1 (13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3)

* `actions/upload-artifact`
  * From: v4 ()
  * To: v4.6.1 (4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1)

* `pyupio/safety-action`
  * From: v1 ()
  * To: v1.0.1 (2591cf2f3e67ba68b923f4c92f0d36e281c65023)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/setup-python`
  * From: v5 ()
  * To: v5.4.0 (42375524e23c412d93fb67b49958b491fce71c38)

* `softprops/action-gh-release`
  * From: v1 ()
  * To: v2.2.1 (c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda)

* `actions/upload-artifact`
  * From: v4 ()
  * To: v4.6.1 (4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1)

* `docker/login-action`
  * From: v3 ()
  * To: v3.3.0 (9780b0c442fbb1117ed29e0efdff1e18412f7567)

* `actions/github-script`
  * From: v7 ()
  * To: v7.0.1 (60a0d83039c74a4aee543508d2ffcb1c3799cdea)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `ThreatFlux/githubWorkFlowChecker`
  * From: v1.0.0 ()
  * To: 20250223.1.17 (fda84ac30f6fdf8548b96f9e1ece3e47e02c463e)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/setup-python`
  * From: v5 ()
  * To: v5.4.0 (42375524e23c412d93fb67b49958b491fce71c38)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.