### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -13,9 +13,9 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@50e43582977f983f8dfd57a049ea90a0e8cb971e #v1.20250224.9
+        uses: ThreatFlux/githubWorkFlowChecker@3abebcdb2c5d4ce12f6b1d36e24a6d23024d1f40  # v1.20250224.9
         with:
           token: ${{ secrets.GIT_TOKEN }}
           owner: ${{ github.repository_owner }}


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `ThreatFlux/githubWorkFlowChecker`
  * From: 50e43582977f983f8dfd57a049ea90a0e8cb971e (50e43582977f983f8dfd57a049ea90a0e8cb971e)
  * To: v1.20250224.9 (3abebcdb2c5d4ce12f6b1d36e24a6d23024d1f40)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.