### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -57,7 +57,7 @@ jobs:
         fi
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # v5.3.1
+      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574  # v5.4.0
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -14,9 +14,9 @@ jobs:
       actions: read           # Required to read workflow files
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@50e43582977f983f8dfd57a049ea90a0e8cb971e #v1.20250224.9
+        uses: ThreatFlux/githubWorkFlowChecker@a7a1d03c888c73c13d7084a25408c2d5b08cdaae  # v1.20250225.1
         with:
           owner: ${{ github.repository_owner }}
           repo-name: ${{ github.event.repository.name }}


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `codecov/codecov-action`
  * From: 13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 (13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3)
  * To: v5.4.0 (0565863a31f2c772f9f0395002a31e3f06189574)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `ThreatFlux/githubWorkFlowChecker`
  * From: 50e43582977f983f8dfd57a049ea90a0e8cb971e (50e43582977f983f8dfd57a049ea90a0e8cb971e)
  * To: v1.20250225.1 (a7a1d03c888c73c13d7084a25408c2d5b08cdaae)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.