### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Update GitHub Actions
-        uses: ThreatFlux/githubWorkFlowChecker@a7a1d03c888c73c13d7084a25408c2d5b08cdaae  # v1.20250225.1
+        uses: ThreatFlux/githubWorkFlowChecker@e2b259c7ab41241c6fcfe8fabe121a294c63890d  # v1.20250303.1
         with:
           owner: ${{ github.repository_owner }}
           repo-name: ${{ github.event.repository.name }}


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `ThreatFlux/githubWorkFlowChecker`
  * From: a7a1d03c888c73c13d7084a25408c2d5b08cdaae (a7a1d03c888c73c13d7084a25408c2d5b08cdaae)
  * To: v1.20250303.1 (e2b259c7ab41241c6fcfe8fabe121a294c63890d)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.